### PR TITLE
fix script error

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -28,7 +28,7 @@ PLATFORM="linux/arm/v7"
 
 set -eu
 
-if [[ ! -d ./tailscale/.git ]]
+if [ ! -d ./tailscale/.git ]
 then
     git clone https://github.com/tailscale/tailscale.git
 fi


### PR DESCRIPTION
fix
```
./build.sh: 31: [[: not found
./build.sh: 36: cd: can't cd to tailscale
./build.sh: 38: VERSION_LONG: parameter not set
```