### PR TITLE
Add STARTUP_SCRIPT option to execute extra script during container start

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ This section follows the Mikrotik Container documentation with additional steps 
 | UPDATE_TAILSCALE      | Update tailscale on container startup                         |       |
 | TAILSCALE_ARGS    | Additional arguments passed to tailscale      | Optional. Note ```---accept-routes``` is required to accept the advertised routes of the other subnet routers |
 | TAILSCALED_ARGS   | Additional arguments passed to tailscaled     | Optional                                     |
+| STARTUP_SCRIPT    | Extra script to execute in container before tailscaled | Optional |
 
 Example Tailscale control server configuration:
 ```
@@ -103,6 +104,14 @@ Define the the mount as per below.
 ```
 /container mounts
 add name="tailscale" src="/tailscale" dst="/var/lib/tailscale" 
+```
+
+It's possible to execute extra script during container startup. To do this, firstly make sure that script is accessible inside
+container. For example put it to `/var/lib/tailscale` folder and then add `STARTUP_SCRIPT` environment variable:
+
+```
+/container/envs
+add name="tailscale" key="STARTUP_SCRIPT" value="/var/lib/tailscale/startup.sh"
 ```
 
 6. Create the container

--- a/tailscale.sh
+++ b/tailscale.sh
@@ -34,6 +34,10 @@ if [[ -z "$LOGIN_SERVER" ]]; then
 	LOGIN_SERVER=https://controlplane.tailscale.com
 fi
 
+if [[ -n "$STARTUP_SCRIPT" ]]; then
+       bash "$STARTUP_SCRIPT" || exit $?
+fi
+
 # Start tailscaled and bring tailscale up
 /usr/local/bin/tailscaled ${TAILSCALED_ARGS} &
 until /usr/local/bin/tailscale up \


### PR DESCRIPTION
This adds `STARTUP_SCRIPT` environment variable to execute custom script during container startup.

My motivation for this is to define custom `iptables` rules that are needed to make it work as exit node. It's not trivial setup because tailscale uses certain `iptables` features that are not available in Mikrotik containers. But it's possible to workaround this. 

I've tested it with latest Tailscale 1.78. So I'll most likely send pull request that updates tailscale and alpine later.